### PR TITLE
Add option to set custom L2 chain

### DIFF
--- a/Set_Syncer/index.js
+++ b/Set_Syncer/index.js
@@ -33,7 +33,7 @@ try {
     process.exit(1);
 }
 process.env.PRIVATE_KEY = privateKeyDeployer;
-const output = execSync(`othentic-cli network set-syncer --syncer-address ${syncerAddress}`, { encoding: 'utf-8'});
+const output = execSync(`othentic-cli network set-syncer --syncer-address ${syncerAddress} --l2-chain ${process.argv[3]}`, { encoding: 'utf-8'});
 console.log(output);
 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ x-othentic-cli: &othentic-cli
 services:
   aggregator:
     <<: *othentic-cli
-    command: ["node", "aggregator", "--json-rpc", "--l1-chain", "holesky", "--l2-chain", "amoy"]
+    command: ["node", "aggregator", "--json-rpc", "--l1-chain", "holesky", "--l2-chain", "${L2:-amoy}"]
     environment:
       - PRIVATE_KEY=${PRIVATE_KEY_AGGREGATOR:-${PRIVATE_KEY:-}}
     ports:
@@ -26,7 +26,7 @@ services:
       "--avs-webapi",
       "http://10.8.0.42",
       "--l1-chain", "holesky",
-      "--l2-chain", "amoy",
+      "--l2-chain", "${L2:-amoy}",
     ]
     environment:
       - PRIVATE_KEY=${PRIVATE_KEY_ATTESTER1:-${PRIVATE_KEY_VALIDATOR1:-}}
@@ -46,7 +46,7 @@ services:
       "--avs-webapi",
       "http://10.8.0.42",
       "--l1-chain", "holesky",
-      "--l2-chain", "amoy",
+      "--l2-chain", "${L2:-amoy}",
     ]
     environment:
       - PRIVATE_KEY=${PRIVATE_KEY_ATTESTER2:-${PRIVATE_KEY_VALIDATOR2:-}}
@@ -66,7 +66,7 @@ services:
       "--avs-webapi",
       "http://10.8.0.42",
       "--l1-chain", "holesky",
-      "--l2-chain", "amoy",
+      "--l2-chain", "${L2:-amoy}",
     ]
     environment:
       - PRIVATE_KEY=${PRIVATE_KEY_ATTESTER3:-${PRIVATE_KEY_VALIDATOR3:-}}
@@ -83,6 +83,9 @@ services:
     build:
       context: .
       dockerfile: ./Set_Syncer/Dockerfile
+    command: [
+      "--l2-chain", "${L2:-amoy}",
+    ]
   syncer:
     <<: *othentic-cli
     command: [
@@ -90,7 +93,7 @@ services:
       "sync",
       "--sync-interval", "12h",
       "--l1-chain", "holesky",
-      "--l2-chain", "amoy",
+      "--l2-chain", "${L2:-amoy}",
     ]
     environment:
       - PRIVATE_KEY=${PRIVATE_KEY_SYNCER}


### PR DESCRIPTION
This PR implements the option to add `L2=...` to the compose command to run the nodes with a custom L2.
For example:
```
L2=base-sepolia docker-compose up --build
```