### PR TITLE
Change env var usage in docker compose

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,7 +19,7 @@ OTHENTIC_BOOTSTRAP_SEED=97a64de0fb18532d4ce56fb35b730aedec993032b533f783b04c9175
 L1_RPC=
 L2_RPC=
 
-# Set the L1/L2 Chain ids
+# Set the L1/L2 Chain names
 L1_CHAIN=
 L2_CHAIN=  
 

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,4 +1,3 @@
-version: '3.7'
 x-othentic-cli: &othentic-cli
   env_file:
     - .env
@@ -14,15 +13,14 @@ services:
       "--json-rpc",
       # Enable custom messaging if needed 
       # "--json-rpc.custom-message-enabled",
-      "--l1-chain", "mainnet",
-      # Set the L2 chain 
-      "--l2-chain", "base", 
       "--internal-tasks",
       "--metrics",
       "--p2p.datadir", "data/peerstore/aggregator"
     ]
     environment:
       - PRIVATE_KEY=${PRIVATE_KEY_AGGREGATOR}
+      - L1_CHAIN=${L1_CHAIN}
+      - L2_CHAIN=${L2_CHAIN}
       - LOG_DIR=data/logs/aggregator
     volumes:
       - ./data/peerstore/aggregator:/app/data/peerstore/aggregator
@@ -44,9 +42,6 @@ services:
       # "--json-rpc.custom-message-enabled",
       "--avs-webapi",
       "http://10.8.0.42",
-      "--l1-chain", "mainnet",
-      # Set the L2 chain 
-      "--l2-chain", "base",
       "--metrics",
       "--p2p.datadir", "data/peerstore/attester1",
       # Setup using https://docs.othentic.xyz/main/avs-framework/othentic-cli/node-operators#features
@@ -55,6 +50,8 @@ services:
     ]
     environment:
       - PRIVATE_KEY=${PRIVATE_KEY_ATTESTER1}
+      - L1_CHAIN=${L1_CHAIN}
+      - L2_CHAIN=${L2_CHAIN}
       - LOG_DIR=data/logs/attester1
     volumes:
       - ./data/peerstore/attester1:/app/data/peerstore/attester1
@@ -79,9 +76,6 @@ services:
       # "--json-rpc.custom-message-enabled",
       "--avs-webapi",
       "http://10.8.0.42",
-      "--l1-chain", "mainnet",
-      # Set the L2 chain 
-      "--l2-chain", "base",
       "--metrics",
       "--p2p.datadir", "data/peerstore/attester2",
       # Setup using https://docs.othentic.xyz/main/avs-framework/othentic-cli/node-operators#features
@@ -90,6 +84,8 @@ services:
     ]
     environment:
       - PRIVATE_KEY=${PRIVATE_KEY_ATTESTER2}
+      - L1_CHAIN=${L1_CHAIN}
+      - L2_CHAIN=${L2_CHAIN}
       - LOG_DIR=data/logs/attester2
     volumes:
       - ./data/peerstore/attester2:/app/data/peerstore/attester2
@@ -114,9 +110,6 @@ services:
       # "--json-rpc.custom-message-enabled",
       "--avs-webapi",
       "http://10.8.0.42",
-      "--l1-chain", "mainnet",
-      # Set the L2 chain 
-      "--l2-chain", "base",
       "--metrics",
       "--p2p.datadir", "data/peerstore/attester3",
       # Setup using https://docs.othentic.xyz/main/avs-framework/othentic-cli/node-operators#features
@@ -125,6 +118,8 @@ services:
     ]
     environment:
       - PRIVATE_KEY=${PRIVATE_KEY_ATTESTER3}
+      - L1_CHAIN=${L1_CHAIN}
+      - L2_CHAIN=${L2_CHAIN}
       - LOG_DIR=data/logs/attester3
     volumes:
       - ./data/peerstore/attester3:/app/data/peerstore/attester3

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3.7'
 x-othentic-cli: &othentic-cli
   env_file:
     - .env
@@ -12,13 +11,12 @@ services:
       "node",
       "aggregator",
       "--json-rpc",
-      "--l1-chain", "holesky",
-      # Set the L2 chain
-      "--l2-chain", "amoy",
       "--internal-tasks"
     ]
     environment:
       - PRIVATE_KEY=${PRIVATE_KEY_AGGREGATOR}
+      - L1_CHAIN=${L1_CHAIN}
+      - L2_CHAIN=${L2_CHAIN}
     ports:
       - "8545:8545"
       - "9876:9876"
@@ -33,12 +31,11 @@ services:
       "/ip4/10.8.0.69/tcp/9876/p2p/${OTHENTIC_BOOTSTRAP_ID}",
       "--avs-webapi",
       "http://10.8.0.42",
-      "--l1-chain", "holesky",
-      # Set the L2 chain 
-      "--l2-chain", "amoy",
     ]
     environment:
       - PRIVATE_KEY=${PRIVATE_KEY_ATTESTER1}
+      - L1_CHAIN=${L1_CHAIN}
+      - L2_CHAIN=${L2_CHAIN}
     depends_on:
       aggregator:
         condition: service_started
@@ -53,12 +50,11 @@ services:
       "/ip4/10.8.0.69/tcp/9876/p2p/${OTHENTIC_BOOTSTRAP_ID}",
       "--avs-webapi",
       "http://10.8.0.42",
-      "--l1-chain", "holesky",
-      # Set the L2 chain 
-      "--l2-chain", "amoy",
     ]
     environment:
       - PRIVATE_KEY=${PRIVATE_KEY_ATTESTER2}
+      - L1_CHAIN=${L1_CHAIN}
+      - L2_CHAIN=${L2_CHAIN}
     depends_on:
       aggregator:
         condition: service_started
@@ -73,12 +69,11 @@ services:
       "/ip4/10.8.0.69/tcp/9876/p2p/${OTHENTIC_BOOTSTRAP_ID}",
       "--avs-webapi",
       "http://10.8.0.42",
-      "--l1-chain", "holesky",
-      # Set the L2 chain 
-      "--l2-chain", "amoy",
     ]
     environment:
       - PRIVATE_KEY=${PRIVATE_KEY_ATTESTER3}
+      - L1_CHAIN=${L1_CHAIN}
+      - L2_CHAIN=${L2_CHAIN}
     depends_on:
       aggregator:
         condition: service_started


### PR DESCRIPTION
As part of the update to the quickstart guide, I modified the docker-compose file to pull L1 and L2 chain variables from env vars instead of supplying them as flags to the node software.

This makes it less error prone and fits the new quickstart guide we'll publish as part of the docs update.